### PR TITLE
Fix Tag edit command with UUID copy

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TAGS;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -89,10 +90,11 @@ public class EditCommand extends UndoableCommand {
     private static Tag createEditedTag(Tag tagToEdit, EditTagDescriptor editTagDescriptor) {
         assert tagToEdit != null;
 
+        UUID id = tagToEdit.getId();
         Name updatedName = editTagDescriptor.getName().orElse(tagToEdit.getName());
         Description updatedDescription = editTagDescriptor.getDescription().orElse(tagToEdit.getDescription());
 
-        return new Tag(updatedName, updatedDescription);
+        return new Tag(id, updatedName, updatedDescription);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -46,8 +47,9 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TAG_SUCCESS, editedTag);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.updateTag(model.getFilteredTagList().get(0), editedTag);
+        Tag firstTag = model.getFilteredTagList().get(INDEX_FIRST_TAG.getZeroBased());
 
+        expectedModel.updateTag(firstTag, editedTag);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
@@ -69,6 +71,7 @@ public class EditCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.updateTag(lastTag, editedTag);
 
+        assertEquals(lastTag.getId(), editedTag.getId());
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
@@ -96,8 +99,11 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TAG_SUCCESS, editedTag);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.updateTag(model.getFilteredTagList().get(0), editedTag);
+        Tag firstTag = model.getFilteredTagList().get(INDEX_FIRST_TAG.getZeroBased());
 
+        expectedModel.updateTag(firstTag, editedTag);
+
+        assertEquals(firstTag.getId(), editedTag.getId());
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 


### PR DESCRIPTION
Update tests and command to ensure UUID has no change when updating a tag.