### PR TITLE
Add ability to filter cards based on selected tag

### DIFF
--- a/src/main/java/seedu/address/commons/events/ui/TagListPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/TagListPanelSelectionChangedEvent.java
@@ -3,6 +3,7 @@ package seedu.address.commons.events.ui;
 import seedu.address.commons.events.BaseEvent;
 import seedu.address.ui.TagCard;
 
+//@@author yong-jie
 /**
  * Represents a selection change in the Tag List Panel
  */

--- a/src/main/java/seedu/address/logic/commands/EditCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCardCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BACK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FRONT;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/seedu/address/logic/commands/EditCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCardCommand.java
@@ -65,7 +65,7 @@ public class EditCardCommand extends UndoableCommand {
         } catch (CardNotFoundException pnfe) {
             throw new AssertionError("The target card cannot be missing");
         }
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.showAllCards();
         return new CommandResult(String.format(MESSAGE_EDIT_CARD_SUCCESS, editedCard));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCardCommand.java
@@ -13,7 +13,7 @@ public class ListCardCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.showAllCards();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCardCommand.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
-
 /**
  * Lists all cards in the card book.
  */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,10 +50,15 @@ public interface Model {
     void updateFilteredTagList(Predicate<Tag> predicate);
 
     /**
-     * Updates the filter of the filtered card list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
+     * Resets the filtered card list to contain all cards.
      */
-    void updateFilteredCardList(Predicate<Card> predicate);
+    void showAllCards();
+
+    /**
+     * Sets the card list to contain only those with given tag.
+     * @param tag
+     */
+    void filterCardsByTag(Tag tag);
 
     /** Adds the given card */
     void addCard(Card card) throws DuplicateCardException;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,6 +50,12 @@ public interface Model {
     void updateFilteredTagList(Predicate<Tag> predicate);
 
     /**
+     * Updates the filter of the filtered card list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredCardList(Predicate<Card> predicate);
+
+    /**
      * Resets the filtered card list to contain all cards.
      */
     void showAllCards();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,12 +50,6 @@ public interface Model {
     void updateFilteredTagList(Predicate<Tag> predicate);
 
     /**
-     * Updates the filter of the filtered card list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
-     */
-    void updateFilteredCardList(Predicate<Card> predicate);
-
-    /**
      * Resets the filtered card list to contain all cards.
      */
     void showAllCards();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -31,7 +31,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final AddressBook addressBook;
     private final FilteredList<Tag> filteredTags;
-    private ObservableList<Card> filteredCards;
+    private final ObservableList<Card> filteredCards;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -44,7 +44,7 @@ public class ModelManager extends ComponentManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         filteredTags = new FilteredList<>(this.addressBook.getTagList());
-        filteredCards.setAll(this.addressBook.getCardList());
+        filteredCards = this.addressBook.getCardList();
     }
 
     public ModelManager() {
@@ -150,6 +150,12 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void showAllCards() {
         filteredCards.setAll(addressBook.getCardList());
+    }
+
+    @Override
+    public void updateFilteredCardList(Predicate<Card> predicate) {
+        requireAllNonNull(predicate);
+        filteredCards.filtered(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -44,7 +44,7 @@ public class ModelManager extends ComponentManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         filteredTags = new FilteredList<>(this.addressBook.getTagList());
-        filteredCards = this.addressBook.getCardList();
+        filteredCards.setAll(this.addressBook.getCardList());
     }
 
     public ModelManager() {
@@ -149,12 +149,12 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void showAllCards() {
-        filteredCards = this.addressBook.getCardList();
+        filteredCards.setAll(addressBook.getCardList());
     }
 
     @Override
     public void filterCardsByTag(Tag tag) {
-        this.filteredCards.setAll(addressBook
+        filteredCards.setAll(addressBook
                 .getCardTag()
                 .getCards(tag, addressBook.getCardList()));
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -44,7 +44,10 @@ public class ModelManager extends ComponentManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         filteredTags = new FilteredList<>(this.addressBook.getTagList());
-        filteredCards = this.addressBook.getCardList();
+
+        // To prevent direct referencing, which would cause setAll() to affect addressBook's list
+        filteredCards = FXCollections.observableArrayList();
+        filteredCards.setAll(this.addressBook.getCardList());
     }
 
     public ModelManager() {
@@ -147,15 +150,10 @@ public class ModelManager extends ComponentManager implements Model {
         indicateAddressBookChanged();
     }
 
+    //@@author yong-jie
     @Override
     public void showAllCards() {
-        filteredCards.setAll(addressBook.getCardList());
-    }
-
-    @Override
-    public void updateFilteredCardList(Predicate<Card> predicate) {
-        requireAllNonNull(predicate);
-        filteredCards.filtered(predicate);
+        filteredCards.setAll(this.addressBook.getCardList());
     }
 
     @Override
@@ -165,11 +163,13 @@ public class ModelManager extends ComponentManager implements Model {
                 .getCards(tag, addressBook.getCardList()));
     }
 
+    //@@author
     @Override
     public ObservableList<Card> getFilteredCardList() {
         return FXCollections.unmodifiableObservableList(filteredCards);
     }
 
+    //@@author yong-jie
     @Subscribe
     private void handleTagListPanelSelectionEvent(TagListPanelSelectionChangedEvent event) {
         filterCardsByTag(event.getNewSelection().tag);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import com.google.common.eventbus.Subscribe;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -153,7 +154,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void filterCardsByTag(Tag tag) {
-        this.filteredCards.setAll( addressBook
+        this.filteredCards.setAll(addressBook
                 .getCardTag()
                 .getCards(tag, addressBook.getCardList()));
     }

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -98,7 +98,7 @@ public class UniqueCardList implements Iterable<Card> {
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Card> asObservableList() {
-        return FXCollections.unmodifiableObservableList(internalList);
+        return internalList;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -95,7 +95,7 @@ public class UniqueCardList implements Iterable<Card> {
     }
 
     /**
-     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     * Returns the backing list as an {@code ObservableList}.
      */
     public ObservableList<Card> asObservableList() {
         return internalList;

--- a/src/main/java/seedu/address/model/cardtag/CardTag.java
+++ b/src/main/java/seedu/address/model/cardtag/CardTag.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.card.Card;
 import seedu.address.model.tag.Tag;
@@ -65,7 +66,7 @@ public class CardTag {
         if (cards != null) {
             return cardList.filtered(card -> cards.contains(card.getId().toString()));
         } else {
-            return Collections.emptyList();
+            return FXCollections.observableArrayList();
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -143,7 +143,7 @@ public class AddCommandTest {
             fail("This method should not be called.");
         }
 
-        @Override
+        //@Override
         public void updateFilteredCardList(Predicate<Card> predicate) {
             fail("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -142,7 +142,7 @@ public class AddCommandTest {
         public void updateFilteredTagList(Predicate<Tag> predicate) {
             fail("This method should not be called.");
         }
-        
+
         @Override
         public void filterCardsByTag(Tag tag) {
             fail("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -142,12 +142,7 @@ public class AddCommandTest {
         public void updateFilteredTagList(Predicate<Tag> predicate) {
             fail("This method should not be called.");
         }
-
-        //@Override
-        public void updateFilteredCardList(Predicate<Card> predicate) {
-            fail("This method should not be called.");
-        }
-
+        
         @Override
         public void filterCardsByTag(Tag tag) {
             fail("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -149,6 +149,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void filterCardsByTag(Tag tag) {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void showAllCards() {
+            fail("This method should not be called.");
+        }
+
+        @Override
         public void addCard(Card card) throws DuplicateCardException {
             fail("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
@@ -20,7 +19,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.card.Card;
-import seedu.address.model.card.UuidPredicate;
 import seedu.address.model.tag.NameContainsKeywordsPredicate;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.exceptions.TagNotFoundException;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -152,20 +152,6 @@ public class CommandTestUtil {
     }
 
     /**
-     * Updates {@code model}'s filtered list to show only the card at the given {@code targetIndex} in the
-     * {@code model}'s address book.
-     */
-    public static void showCardAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredCardList().size());
-
-        Card card = model.getFilteredCardList().get(targetIndex.getZeroBased());
-        final UUID uuid = card.getId();
-        model.updateFilteredCardList(new UuidPredicate(uuid));
-
-        assertEquals(1, model.getFilteredCardList().size());
-    }
-
-    /**
      * Deletes the first tag in {@code model}'s filtered list from {@code model}'s address book.
      */
     public static void deleteFirstTag(Model model) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -165,9 +165,7 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredCardList().size());
     }
 
-
     /**
-     *
      * Deletes the first tag in {@code model}'s filtered list from {@code model}'s address book.
      */
     public static void deleteFirstTag(Model model) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -165,7 +165,9 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredCardList().size());
     }
 
+
     /**
+     *
      * Deletes the first tag in {@code model}'s filtered list from {@code model}'s address book.
      */
     public static void deleteFirstTag(Model model) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCardCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.prepareRedoCommand;
 import static seedu.address.logic.commands.CommandTestUtil.prepareUndoCommand;
-import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
@@ -22,6 +21,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.card.Card;
+import seedu.address.model.tag.Description;
+import seedu.address.model.tag.Name;
+import seedu.address.model.tag.Tag;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -54,8 +56,6 @@ public class DeleteCardCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() throws Exception {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
-
         Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
         DeleteCardCommand deleteCardCommand = prepareCommand(INDEX_FIRST_CARD);
 
@@ -63,18 +63,15 @@ public class DeleteCardCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteCard(cardToDelete);
-        showNoCard(expectedModel);
 
         assertCommandSuccess(deleteCardCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
+        model.filterCardsByTag(new Tag(new Name("Hi"), new Description("Bye")));
 
         Index outOfBoundIndex = INDEX_SECOND_CARD;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getCardList().size());
 
         DeleteCardCommand deleteCardCommand = prepareCommand(outOfBoundIndex);
 
@@ -133,7 +130,6 @@ public class DeleteCardCommandTest {
         DeleteCardCommand deleteCardCommand = prepareCommand(INDEX_FIRST_CARD);
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        showCardAtIndex(model, INDEX_SECOND_CARD);
         Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
         // delete -> deletes second card in unfiltered card list / first card in filtered card list
         deleteCardCommand.execute();
@@ -181,14 +177,5 @@ public class DeleteCardCommandTest {
         DeleteCardCommand deleteCardCommand = new DeleteCardCommand(index);
         deleteCardCommand.setData(model, new CommandHistory(), new UndoRedoStack());
         return deleteCardCommand;
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoCard(Model model) {
-        model.updateFilteredCardList(p -> false);
-
-        assertTrue(model.getFilteredCardList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCardCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.assertEqualCardId;
 import static seedu.address.logic.commands.CommandTestUtil.prepareRedoCommand;
 import static seedu.address.logic.commands.CommandTestUtil.prepareUndoCommand;
-import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
@@ -28,6 +27,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.card.Card;
+import seedu.address.model.tag.Description;
+import seedu.address.model.tag.Name;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.CardBuilder;
 import seedu.address.testutil.EditCardDescriptorBuilder;
 
@@ -97,8 +99,6 @@ public class EditCardCommandTest {
 
     @Test
     public void execute_filteredList_success() throws Exception {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
-
         Card cardInFilteredList = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
         Card editedCard = new CardBuilder(cardInFilteredList).withFront(VALID_NAME_COMSCI).build();
         EditCardCommand editCommand = prepareCommand(INDEX_FIRST_CARD,
@@ -125,8 +125,6 @@ public class EditCardCommandTest {
 
     @Test
     public void execute_duplicateCardFilteredList_failure() {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
-
         // edit card in filtered list into a duplicate in address book
         Card cardInList = model.getAddressBook().getCardList().get(INDEX_SECOND_CARD.getZeroBased());
         EditCardCommand editCommand = prepareCommand(INDEX_FIRST_CARD,
@@ -151,7 +149,7 @@ public class EditCardCommandTest {
      */
     @Test
     public void execute_invalidCardIndexFilteredList_failure() {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
+        model.filterCardsByTag(new Tag(new Name("Name"), new Description("Address")));
         Index outOfBoundIndex = INDEX_SECOND_CARD;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getCardList().size());
@@ -227,7 +225,6 @@ public class EditCardCommandTest {
         // To check whether card ID has changed
         assertEqualCardId(targetCard, newCard);
 
-        showCardAtIndex(model, INDEX_SECOND_CARD);
         Card cardToEdit = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
         // edit -> edits second card in unfiltered card list / first card in filtered card list
         editCommand.execute();

--- a/src/test/java/seedu/address/logic/commands/ListCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCardCommandTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/seedu/address/logic/commands/ListCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCardCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 
@@ -36,7 +35,7 @@ public class ListCardCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showCardAtIndex(model, INDEX_FIRST_CARD);
+        model.showAllCards();
         assertCommandSuccess(listCommand, model, ListCardCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/model/card/UniqueCardListTest.java
+++ b/src/test/java/seedu/address/model/card/UniqueCardListTest.java
@@ -1,8 +1,6 @@
 package seedu.address.model.card;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class UniqueCardListTest {
     @Test

--- a/src/test/java/seedu/address/model/card/UniqueCardListTest.java
+++ b/src/test/java/seedu/address/model/card/UniqueCardListTest.java
@@ -5,14 +5,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class UniqueCardListTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+    public void asObservableList_modifyList_noError() {
         UniqueCardList uniqueCardList = new UniqueCardList();
-        thrown.expect(UnsupportedOperationException.class);
-        uniqueCardList.asObservableList().remove(0);
+        uniqueCardList.asObservableList().add(new Card("hi", "bye"));
     }
-
 }


### PR DESCRIPTION
I'm submitting an incomplete PR because discussion needs to be done before any progress can be made.

After removing the predicate mechanism of the filteredCardList in ModelManager.java, test cases that rely on the predicate system have begun to fail. The following is an example in CommandTestUtil.java that is causing a lot of command tests to fail.

```
/**
     * Updates {@code model}'s filtered list to show only the card at the given {@code targetIndex} in the
     * {@code model}'s address book.
     */
    public static void showCardAtIndex(Model model, Index targetIndex) {
        assertTrue(targetIndex.getZeroBased() < model.getFilteredCardList().size());

        Card card = model.getFilteredCardList().get(targetIndex.getZeroBased());
        final UUID uuid = card.getId();
        // PROBLEM IS HERE:
        model.updateFilteredCardList(new UuidPredicate(uuid));

        assertEquals(1, model.getFilteredCardList().size());
    }
```

It feels like forcing the list to display only a single card through this predicate violates the design that we intended, which is to obtain the list of cards through feeding it a desired tag.

I'm considering nuking those test cases (or at least the specific checks) that rely on these methods of filtering, but this is ultimately a decision that the whole team has to agree on since this will likely cause coverage to drop. About 18 tests are failing as a result of the change in filtering system.